### PR TITLE
Pull out MeSH terms from PubMed records

### DIFF
--- a/ncbiutils/pubmed.py
+++ b/ncbiutils/pubmed.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import Optional, List, Dict, Any
 
+
 #############################
 #   Classes
 #############################
@@ -91,6 +92,9 @@ class Citation(BaseModel):
         MeSH codes https://www.nlm.nih.gov/mesh/pubtypes.html
     correspondence: List[Dict[str, Any]]
         Catch-all for correspondence fields
+    correspondence: List[Dict[str, Any]]
+    mesh_list
+        Collection of MeSH DescriptorName, QualifierName(s)
     """
 
     pmid: str
@@ -102,3 +106,4 @@ class Citation(BaseModel):
     journal: Journal
     publication_type_list: List[str]
     correspondence: List[Dict[str, Any]]
+    mesh_list: Optional[List[Dict[str, Any]]]

--- a/ncbiutils/pubmedxmlparser.py
+++ b/ncbiutils/pubmedxmlparser.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional, List, Generator
+from typing import Optional, List, Generator, Dict, Any
 import re
 from typing_extensions import TypeAlias
 from ncbiutils.pubmed import Author, Journal, Citation
@@ -113,6 +113,24 @@ class PubmedXmlParser(BaseModel):
         uids = [element.get('UI') for element in publication_types]
         return uids
 
+    def _get_ui(self, element: Element) -> Dict[str, str]:
+        ui = element.get('UI')
+        value = _collect_element_text(element)
+        return {'ui': ui, 'value': value}
+
+    def _get_mesh_heading(self, mesh_heading: Element) -> Dict[str, Any]:
+        heading: Dict[str, Any] = {}
+        descriptor_name = _find_safe(mesh_heading, './/DescriptorName')
+        heading['descriptor_name'] = self._get_ui(descriptor_name)
+        qualifier_name_list = _find_all(mesh_heading, './/QualifierName')
+        heading['qualifier_name'] = [self._get_ui(qualifier_name) for qualifier_name in qualifier_name_list]
+        return heading
+
+    def _get_mesh_list(self, pubmed_article: PubmedArticle) -> Optional[List[Dict[str, Any]]]:
+        mesh_heading_list = _find_all(pubmed_article, './/MedlineCitation/MeshHeadingList/MeshHeading')
+        mesh_list = [self._get_mesh_heading(mesh_heading) for mesh_heading in mesh_heading_list]
+        return mesh_list if len(mesh_list) > 0 else None
+
     def parse(self, xml_tree: XmlTree) -> Generator[Citation, None, None]:
         """Parse an XML document to a list of custom citations"""
         pubmed_article_set = self._get_PubmedArticleSet(xml_tree)
@@ -127,6 +145,7 @@ class PubmedXmlParser(BaseModel):
             author_list = self._get_author_list(pubmed_article)
             journal = self._get_journal(pubmed_article)
             publication_type_list = self._get_pubtypes(pubmed_article)
+            mesh_list = self._get_mesh_list(pubmed_article)
             citation = Citation(
                 pmid=pmid,
                 pmc=pmc,
@@ -137,5 +156,6 @@ class PubmedXmlParser(BaseModel):
                 journal=journal,
                 publication_type_list=publication_type_list,
                 correspondence=[],
+                mesh_list=mesh_list,
             )
             yield citation

--- a/ncbiutils/pubmedxmlparser.py
+++ b/ncbiutils/pubmedxmlparser.py
@@ -123,7 +123,8 @@ class PubmedXmlParser(BaseModel):
         descriptor_name = _find_safe(mesh_heading, './/DescriptorName')
         heading['descriptor_name'] = self._get_ui(descriptor_name)
         qualifier_name_list = _find_all(mesh_heading, './/QualifierName')
-        heading['qualifier_name'] = [self._get_ui(qualifier_name) for qualifier_name in qualifier_name_list]
+        if len(qualifier_name_list) > 0:
+            heading['qualifier_name'] = [self._get_ui(qualifier_name) for qualifier_name in qualifier_name_list]
         return heading
 
     def _get_mesh_list(self, pubmed_article: PubmedArticle) -> Optional[List[Dict[str, Any]]]:

--- a/tests/test_pubmedxmlparser.py
+++ b/tests/test_pubmedxmlparser.py
@@ -47,7 +47,8 @@ class TestPubmedXmlParserClass(object):
         assert len(result) == 0
 
     @pytest.mark.parametrize(
-        'pmid, pmc, doi, abstract, title, last_name, email, jtitle, issn, volume, issue, pub_year, pub_type, mesh_heading',
+        'pmid, pmc, doi, abstract, title, last_name, email, jtitle,'
+        ' issn, volume, issue, pub_year, pub_type, mesh_heading',
         [
             (
                 '31302001',
@@ -64,25 +65,13 @@ class TestPubmedXmlParserClass(object):
                 '2019',
                 'D016428',
                 {
-                    'descriptor_name': {
-                        'ui': 'D008928',
-                        'value': 'Mitochondria'
-                    },
+                    'descriptor_name': {'ui': 'D008928', 'value': 'Mitochondria'},
                     'qualifier_name': [
-                        {
-                            'ui': 'Q000235',
-                            'value': 'genetics'
-                        },
-                        {
-                            'ui': 'Q000378',
-                            'value': 'metabolism'
-                        }
-                        {
-                            'ui': 'Q000473',
-                            'value': 'pathology'
-                        }
-                    ]
-                }
+                        {'ui': 'Q000235', 'value': 'genetics'},
+                        {'ui': 'Q000378', 'value': 'metabolism'},
+                        {'ui': 'Q000473', 'value': 'pathology'},
+                    ],
+                },
             ),
             (
                 '22454523',
@@ -98,6 +87,10 @@ class TestPubmedXmlParserClass(object):
                 'Pt 13',
                 '2012',
                 'D016428',
+                {
+                    'descriptor_name': {'ui': 'D050861', 'value': 'Synaptotagmin II'},
+                    'qualifier_name': [{'ui': 'Q000378', 'value': 'metabolism'}],
+                },
             ),
         ],
     )
@@ -135,10 +128,18 @@ class TestPubmedXmlParserClass(object):
         assert journal.issue == issue
         assert journal.pub_year == pub_year
         assert pub_type in result.publication_type_list
-        ameshheading = next(heading for heading in result.mesh_list if heading['descriptor_name']['ui'] == mesh_heading['descriptor_name']['ui'])
+        ameshheading = next(
+            heading
+            for heading in result.mesh_list
+            if heading['descriptor_name']['ui'] == mesh_heading['descriptor_name']['ui']
+        )
         assert ameshheading['descriptor_name']['value'] == mesh_heading['descriptor_name']['value']
         qualifier_values = [qualifier['value'] for qualifier in mesh_heading['qualifier_name']]
-        aqualifiername = next(qualifier for qualifier in ameshheading['qualifier_name'] if qualifier['ui'] == qualifier_values[0])
+        aqualifiername = next(
+            qualifier
+            for qualifier in ameshheading['qualifier_name']
+            if qualifier['ui'] == mesh_heading['qualifier_name'][0]['ui']
+        )
         assert aqualifiername['value'] in qualifier_values
 
     @pytest.mark.parametrize(
@@ -192,10 +193,11 @@ class TestPubmedXmlParserClass(object):
         assert journal.issue == issue
         assert journal.pub_year == pub_year
         assert pub_type in result.publication_type_list
+        assert result.mesh_list is None
 
     @pytest.mark.parametrize(
         'pmid, pmc, doi, abstract, title, last_name, email, collective_name, jtitle,'
-        ' issn, volume, issue, pub_year, pub_type',
+        ' issn, volume, issue, pub_year, pub_type, mesh_heading',
         [
             (
                 '30158200',
@@ -212,6 +214,14 @@ class TestPubmedXmlParserClass(object):
                 None,
                 '2018',
                 'D017418',
+                {
+                    'descriptor_name': {'ui': 'D010024', 'value': 'Osteoporosis'},
+                    'qualifier_name': [
+                        {'ui': 'Q000453', 'value': 'epidemiology'},
+                        {'ui': 'Q000235', 'value': 'genetics'},
+                        {'ui': 'Q000503', 'value': 'physiopathology'},
+                    ],
+                },
             ),
         ],
     )
@@ -231,6 +241,7 @@ class TestPubmedXmlParserClass(object):
         issue,
         pub_year,
         pub_type,
+        mesh_heading,
         shared_datadir,
     ):
         data = (shared_datadir / 'markup.xml').read_bytes()
@@ -252,9 +263,23 @@ class TestPubmedXmlParserClass(object):
         assert journal.issue == issue
         assert journal.pub_year == pub_year
         assert pub_type in result.publication_type_list
+        ameshheading = next(
+            heading
+            for heading in result.mesh_list
+            if heading['descriptor_name']['ui'] == mesh_heading['descriptor_name']['ui']
+        )
+        assert ameshheading['descriptor_name']['value'] == mesh_heading['descriptor_name']['value']
+        qualifier_values = [qualifier['value'] for qualifier in mesh_heading['qualifier_name']]
+        aqualifiername = next(
+            qualifier
+            for qualifier in ameshheading['qualifier_name']
+            if qualifier['ui'] == mesh_heading['qualifier_name'][0]['ui']
+        )
+        assert aqualifiername['value'] in qualifier_values
 
     @pytest.mark.parametrize(
-        'pmid, pmc, doi, abstract, title, last_name, orcid, jtitle, issn, volume, issue, pub_year, pub_type',
+        'pmid, pmc, doi, abstract, title, last_name, orcid, jtitle,'
+        ' issn, volume, issue, pub_year, pub_type, mesh_heading',
         [
             (
                 '32820036',
@@ -270,6 +295,10 @@ class TestPubmedXmlParserClass(object):
                 '17-18',
                 '2020',
                 'D052061',
+                {
+                    'descriptor_name': {'ui': 'D015972', 'value': 'Gene Expression Regulation, Neoplastic'},
+                    'qualifier_name': [{'ui': 'Q000235', 'value': 'genetics'}],
+                },
             ),
         ],
     )
@@ -288,6 +317,7 @@ class TestPubmedXmlParserClass(object):
         issue,
         pub_year,
         pub_type,
+        mesh_heading,
         shared_datadir,
     ):
         data = (shared_datadir / 'orcid.xml').read_bytes()
@@ -307,3 +337,16 @@ class TestPubmedXmlParserClass(object):
         assert journal.issue == issue
         assert journal.pub_year == pub_year
         assert pub_type in result.publication_type_list
+        ameshheading = next(
+            heading
+            for heading in result.mesh_list
+            if heading['descriptor_name']['ui'] == mesh_heading['descriptor_name']['ui']
+        )
+        assert ameshheading['descriptor_name']['value'] == mesh_heading['descriptor_name']['value']
+        qualifier_values = [qualifier['value'] for qualifier in mesh_heading['qualifier_name']]
+        aqualifiername = next(
+            qualifier
+            for qualifier in ameshheading['qualifier_name']
+            if qualifier['ui'] == mesh_heading['qualifier_name'][0]['ui']
+        )
+        assert aqualifiername['value'] in qualifier_values

--- a/tests/test_pubmedxmlparser.py
+++ b/tests/test_pubmedxmlparser.py
@@ -47,7 +47,7 @@ class TestPubmedXmlParserClass(object):
         assert len(result) == 0
 
     @pytest.mark.parametrize(
-        'pmid, pmc, doi, abstract, title, last_name, email, jtitle, issn, volume, issue, pub_year, pub_type',
+        'pmid, pmc, doi, abstract, title, last_name, email, jtitle, issn, volume, issue, pub_year, pub_type, mesh_heading',
         [
             (
                 '31302001',
@@ -63,6 +63,26 @@ class TestPubmedXmlParserClass(object):
                 '4',
                 '2019',
                 'D016428',
+                {
+                    'descriptor_name': {
+                        'ui': 'D008928',
+                        'value': 'Mitochondria'
+                    },
+                    'qualifier_name': [
+                        {
+                            'ui': 'Q000235',
+                            'value': 'genetics'
+                        },
+                        {
+                            'ui': 'Q000378',
+                            'value': 'metabolism'
+                        }
+                        {
+                            'ui': 'Q000473',
+                            'value': 'pathology'
+                        }
+                    ]
+                }
             ),
             (
                 '22454523',
@@ -96,6 +116,7 @@ class TestPubmedXmlParserClass(object):
         issue,
         pub_year,
         pub_type,
+        mesh_heading,
         double_xml,
     ):
         parse_result = self.xmlparser.parse(double_xml)
@@ -114,6 +135,11 @@ class TestPubmedXmlParserClass(object):
         assert journal.issue == issue
         assert journal.pub_year == pub_year
         assert pub_type in result.publication_type_list
+        ameshheading = next(heading for heading in result.mesh_list if heading['descriptor_name']['ui'] == mesh_heading['descriptor_name']['ui'])
+        assert ameshheading['descriptor_name']['value'] == mesh_heading['descriptor_name']['value']
+        qualifier_values = [qualifier['value'] for qualifier in mesh_heading['qualifier_name']]
+        aqualifiername = next(qualifier for qualifier in ameshheading['qualifier_name'] if qualifier['ui'] == qualifier_values[0])
+        assert aqualifiername['value'] in qualifier_values
 
     @pytest.mark.parametrize(
         'pmid, doi, abstract, title, last_name, email, jtitle, issn, volume, issue, pub_year, pub_type',


### PR DESCRIPTION
Extract, when available, the `MeshHeading`s using the PubMed XML parser.

The output will look something like:

```python
mesh_list: [
  {
      'descriptor_name': {'ui': 'D000107', 'value': 'Acetylation'},     
  },
...
  {
      'descriptor_name': {'ui': 'D008928', 'value': 'Mitochondria'},
      'qualifier_name': [
          {'ui': 'Q000235', 'value': 'genetics'},
          {'ui': 'Q000378', 'value': 'metabolism'},
          {'ui': 'Q000473', 'value': 'pathology'},
      ],
  },
...
]              
```